### PR TITLE
✨ Add second progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ easing              | function               | Easing.out(Easing.ease) | Animati
 onAnimationComplete | function               |                         | Function that's invoked when the animation completes (both on mount and if called with `.animate()`)
 onFillChange        | function               |                         | Function that returns current progress on every change
 tintColorSecondary  | string                 | the same as tintColor   | To change fill color from tintColor to tintColorSecondary as animation progresses
+secondFill          | number                 | 0                       | Current second progress / fill
+secondFilltintColor | string                 | the same as tintColor   | Color of the second progress line if exists
 
 `AnimatedCircularProgress` also exposes the following functions:
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ onAnimationComplete | function               |                         | Functio
 onFillChange        | function               |                         | Function that returns current progress on every change
 tintColorSecondary  | string                 | the same as tintColor   | To change fill color from tintColor to tintColorSecondary as animation progresses
 secondFill          | number                 | 0                       | Current second progress / fill
-secondFilltintColor | string                 | the same as tintColor   | Color of the second progress line if exists
+secondFillTintColor | string                 | the same as tintColor   | Color of the second progress line if exists
 
 `AnimatedCircularProgress` also exposes the following functions:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,13 @@ declare module 'react-native-circular-progress' {
      */
     fill: number;
 
+     /**
+     * Second Current progress / fill if exists
+     *
+     * @type {number}
+     */
+    secondFill?: number;
+
     /**
      * Thickness of background circle
      *
@@ -46,6 +53,14 @@ declare module 'react-native-circular-progress' {
      * @default 'black'
      */
     tintColor?: string;
+
+    /**
+     * Color of the second progress line if exists
+     *
+     * @type {string}
+     * @default tintColor
+     */
+    secondFillTintColor?: string;
 
     /**
      * Change the fill color from tintColor to tintColorSecondary as animation progresses.

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -28,6 +28,7 @@ export default class CircularProgress extends React.PureComponent {
       width,
       backgroundWidth,
       tintColor,
+      secondFillTintColor,
       tintTransparency,
       backgroundColor,
       style,
@@ -36,6 +37,7 @@ export default class CircularProgress extends React.PureComponent {
       fillLineCap = lineCap,
       arcSweepAngle,
       fill,
+      secondFill,
       children,
       childrenContainerStyle,
       padding,
@@ -49,11 +51,14 @@ export default class CircularProgress extends React.PureComponent {
     const radius = size / 2 - maxWidthCircle / 2 - padding / 2;
 
     const currentFillAngle = (arcSweepAngle * this.clampFill(fill)) / 100;
+
+    const currentFillSecondAngle = secondFill ? (arcSweepAngle * this.clampFill(secondFill + fill)) / 100 : 0;
+
     const backgroundPath = this.circlePath(
       sizeWithPadding,
       sizeWithPadding,
       radius,
-      tintTransparency ? 0 : currentFillAngle,
+      tintTransparency ? 0 : currentFillAngle + currentFillSecondAngle,
       arcSweepAngle
     );
     const circlePath = this.circlePath(
@@ -63,11 +68,20 @@ export default class CircularProgress extends React.PureComponent {
       0,
       currentFillAngle
     );
+
+    const secondCirclePath = secondFill && this.circlePath(
+      sizeWithPadding,
+      sizeWithPadding,
+      radius,
+      currentFillAngle,
+      currentFillSecondAngle
+    ); 
+
     const coordinate = this.polarToCartesian(
       sizeWithPadding,
       sizeWithPadding,
       radius,
-      currentFillAngle
+      currentFillAngle 
     );
     const cap = this.props.renderCap ? this.props.renderCap({ center: coordinate }) : null;
 
@@ -122,6 +136,16 @@ export default class CircularProgress extends React.PureComponent {
                 fill="transparent"
               />
             )}
+            {secondFill && (
+              <Path
+                d={secondCirclePath}
+                stroke= {secondFillTintColor ? secondFillTintColor : tintColor}
+                strokeWidth={width}
+                strokeLinecap={fillLineCap}
+                strokeDasharray={strokeDasharrayTint}
+                fill="transparent"
+              />
+            )}
             {cap}
           </G>
         </Svg>
@@ -138,9 +162,11 @@ CircularProgress.propTypes = {
     PropTypes.instanceOf(Animated.Value),
   ]).isRequired,
   fill: PropTypes.number.isRequired,
+  secondFill: PropTypes.number,
   width: PropTypes.number.isRequired,
   backgroundWidth: PropTypes.number,
   tintColor: PropTypes.string,
+  secondFillTintColor: PropTypes.string,
   tintTransparency: PropTypes.bool,
   backgroundColor: PropTypes.string,
   rotation: PropTypes.number,


### PR DESCRIPTION
We use your module in our application and a new need has appeared: add a second progess bar in the same circle with another color for example.

So I propose these modifications on the current code to answer this need.

Example:

<img width="321" alt="Capture d’écran 2021-07-20 à 14 45 43" src="https://user-images.githubusercontent.com/43377588/128678258-da0fb000-f013-49fd-aee1-ad8ccb42bfe1.png">
